### PR TITLE
Fix overflow in SplitContainer panel

### DIFF
--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -178,6 +178,7 @@ const Header = styled('h3')`
 const SplitContainer = styled(Panel)`
   display: flex;
   justify-content: center;
+  overflow: hidden;
 `;
 
 const ModuleInfo = styled('div')`


### PR DESCRIPTION
## Summary
- prevent panel content from spilling out in module onboarding

## Testing
- `pre-commit` *(fails: command not found)*
- `npx biome check static/app/views/insights/common/components/modulesOnboarding.tsx` *(fails: EHOSTUNREACH)*